### PR TITLE
Update api.py handle get_username 204 no content error

### DIFF
--- a/mojang/api.py
+++ b/mojang/api.py
@@ -110,7 +110,10 @@ class MojangAPI:
         """
         resp = requests.get(f"https://sessionserver.mojang.com/session/minecraft/profile/{uuid}")
         if resp.ok:
-            return resp.json()["name"]
+            try:
+                return resp.json()["name"]
+            except json.decoder.JSONDecodeError:
+                return None
         return None
 
 


### PR DESCRIPTION
Handling for when the Mojang API responds with a 204 No Content error.

**From the [mojang API docs](https://mojang-api-docs.netlify.app/no-auth/uuid-to-profile.html?highlight=https://sessionserver.mojang.com/session/minecraft/profile/#request):**

> There is no response for this error. If you encounter this error, the UUID you have provided has either never been on a profile or has been on a profile that is hard-deleted.

This happened when one of the users of my discord bot contacted mojang support and got their account "reset". This meant their old UUID was deleted and they were given a new one. My database had their old UUID stored and when trying to update to their latest username, this error was occurring.